### PR TITLE
ci(workflow): 添加id-token权限并启用GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
 
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - name: Generate Token for Bot
@@ -56,6 +57,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm ci:publish
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'


### PR DESCRIPTION
为自动化发布流程添加必要的id-token写入权限
启用changesets action的GitHub Releases创建功能